### PR TITLE
Dexter/connect views

### DIFF
--- a/src/main/java/app/Main.java
+++ b/src/main/java/app/Main.java
@@ -1,9 +1,12 @@
 package app;
 
+import com.mongodb.MongoException;
+import data_access.DAOFacade;
 import interface_adapter.ViewManagerModel;
 import interface_adapter.login.LoginViewModel;
 import interface_adapter.signup.SignupViewModel;
 import interface_adapter.welcome.WelcomeViewModel;
+import view.SignupView;
 import view.ViewManager;
 import view.WelcomeView;
 
@@ -29,6 +32,16 @@ public class Main {
         ViewManagerModel viewManagerModel = new ViewManagerModel();
         new ViewManager(views, cardLayout, viewManagerModel);
 
+        DAOFacade entityDataAccessObject;
+        try {
+            entityDataAccessObject = new DAOFacade();
+            System.out.println("Connected to MongoDB database");
+        } catch (MongoException e) {
+            System.out.println("Couldn't connect to MongoDB database, aborting application...");
+            throw new RuntimeException(e);
+        }
+
+
         // The data for the views, such as username and password, are in the ViewModels.
         // This information will be changed by a presenter object that is reporting the
         // results from the use case. The ViewModels are observable, and will
@@ -39,6 +52,8 @@ public class Main {
 
         WelcomeView welcomeView = WelcomeUseCaseFactory.create(welcomeViewModel, signupViewModel, loginViewModel, viewManagerModel);
         views.add(welcomeView, welcomeView.viewName);
+        SignupView signupView = SignupUseCaseFactory.create(viewManagerModel, welcomeViewModel, signupViewModel, loginViewModel, entityDataAccessObject);
+        views.add(signupView, signupView.viewName);
 
         viewManagerModel.setActiveView(welcomeView.viewName);
         viewManagerModel.firePropertyChanged();

--- a/src/main/java/interface_adapter/signup/SignupPresenter.java
+++ b/src/main/java/interface_adapter/signup/SignupPresenter.java
@@ -36,6 +36,7 @@ public class SignupPresenter implements SignupOutputBoundary {
 
     @Override
     public void prepareFailView(String error) {
+        System.out.println("Sign in failure: " + error);
         SignupState signupState = signupViewModel.getState();
         signupState.setUsernameError(error);
         signupViewModel.firePropertyChanged();

--- a/src/main/java/interface_adapter/signup/SignupPresenter.java
+++ b/src/main/java/interface_adapter/signup/SignupPresenter.java
@@ -24,6 +24,7 @@ public class SignupPresenter implements SignupOutputBoundary {
     @Override
     public void prepareSuccessView(SignupOutputData response) {
         assert !response.isUseCaseFailed();
+        System.out.println("Sign up successful: username" + response.getUsername() + " created in MongoDB");
 
         LoginState loginState = loginViewModel.getState();
         loginState.setUsername(response.getUsername());
@@ -36,7 +37,6 @@ public class SignupPresenter implements SignupOutputBoundary {
 
     @Override
     public void prepareFailView(String error) {
-        System.out.println("Sign in failure: " + error);
         SignupState signupState = signupViewModel.getState();
         signupState.setUsernameError(error);
         signupViewModel.firePropertyChanged();

--- a/src/main/java/interface_adapter/swap_views/welcome/SwaptoWelcomePresenter.java
+++ b/src/main/java/interface_adapter/swap_views/welcome/SwaptoWelcomePresenter.java
@@ -15,7 +15,7 @@ public class SwaptoWelcomePresenter implements SwaptoWelcomeOutputBoundary {
 
     @Override
     public void execute() {
-        viewManagerModel.setActiveView(welcomeViewModel.getViewName());
+        viewManagerModel.setActiveView("welcome");
         viewManagerModel.firePropertyChanged();
     }
 }

--- a/src/main/java/interface_adapter/welcome/WelcomeViewModel.java
+++ b/src/main/java/interface_adapter/welcome/WelcomeViewModel.java
@@ -19,7 +19,7 @@ public class WelcomeViewModel extends ViewModel {
     private final PropertyChangeSupport support = new PropertyChangeSupport(this);
 
     public WelcomeViewModel() {
-        super("Welcome");
+        super("welcome");
     }
     @Override
     public void firePropertyChanged() {

--- a/src/main/java/view/SignupView.java
+++ b/src/main/java/view/SignupView.java
@@ -15,7 +15,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
 public class SignupView extends JPanel implements ActionListener, PropertyChangeListener {
-    public final String viewName = "sign up";
+    public final String viewName;
     private final JTextField usernameInputField;
     private final JPasswordField passwordInputField;
     private final JPasswordField repeatPasswordInputField;
@@ -25,6 +25,8 @@ public class SignupView extends JPanel implements ActionListener, PropertyChange
     public SignupView(SignupViewModel signupViewModel,
                       SignupController signupController,
                       SwaptoWelcomeController swapController) {
+        this.viewName = signupViewModel.getViewName();
+
         // Create and do settings for main panel
         this.setLayout(new FlowLayout(FlowLayout.CENTER, 150, 30));
         this.setBackground(Color.lightGray);

--- a/src/main/java/view/SignupView.java
+++ b/src/main/java/view/SignupView.java
@@ -26,6 +26,7 @@ public class SignupView extends JPanel implements ActionListener, PropertyChange
                       SignupController signupController,
                       SwaptoWelcomeController swapController) {
         this.viewName = signupViewModel.getViewName();
+        signupViewModel.addPropertyChangeListener(this);
 
         // Create and do settings for main panel
         this.setLayout(new FlowLayout(FlowLayout.CENTER, 150, 30));
@@ -163,7 +164,7 @@ public class SignupView extends JPanel implements ActionListener, PropertyChange
                         signupController.execute(
                                 currentState.getUsername(),
                                 currentState.getPassword(),
-                                currentState.getPasswordError(),
+                                currentState.getRepeatPassword(),
                                 currentState.isDoctor()
                         );
                     }
@@ -191,5 +192,7 @@ public class SignupView extends JPanel implements ActionListener, PropertyChange
         } else if (state.getPasswordError() != null) {
             JOptionPane.showMessageDialog(this, state.getPasswordError());
         }
+        state.setUsernameError(null);
+        state.setPasswordError(null);
     }
 }

--- a/src/main/java/view/WelcomeView.java
+++ b/src/main/java/view/WelcomeView.java
@@ -11,7 +11,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
 public class WelcomeView extends JPanel implements ActionListener {
-    public final String viewName = "welcome";
+    public final String viewName;
     private final JButton logInButton;
     private final JButton signUpButton;
     private final JLabel label;
@@ -20,6 +20,8 @@ public class WelcomeView extends JPanel implements ActionListener {
     public WelcomeView(WelcomeViewModel welcomeViewModel,
                        WelcomeSignupController signupController,
                        WelcomeLoginController loginController) {
+        this.viewName = welcomeViewModel.getViewName();
+
         // Create and do settings for main panel
         this.setLayout(new FlowLayout(FlowLayout.CENTER, 100, 65));
         this.setBackground(Color.lightGray);

--- a/src/test/java/use_case/signup/SignupInteractorTest.java
+++ b/src/test/java/use_case/signup/SignupInteractorTest.java
@@ -1,6 +1,103 @@
 package use_case.signup;
 
+import data_access.InMemoryUserDataAccessObject;
+import entity.people.DoctorUserFactory;
+import entity.people.PatientUserFactory;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
 public class SignupInteractorTest {
-    void successTest(){
+    @Test
+    public void signupPatientSuccessTest() {
+        SignupUserDataAccessInterface userDAO = new InMemoryUserDataAccessObject();
+        DoctorUserFactory docFactory = new DoctorUserFactory();
+        PatientUserFactory patFactory = new PatientUserFactory();
+        SignupOutputBoundary signupPresenter = new SignupOutputBoundary() {
+            @Override
+            public void prepareSuccessView(SignupOutputData user) {
+                assertTrue(userDAO.existsByName(false, user.getUsername()));
+                assertFalse(user.isUseCaseFailed());
+            }
+
+            @Override
+            public void prepareFailView(String error) {
+                fail("Test expected to pass.");
+            }
+        };
+        SignupInteractor signupInteractor = new SignupInteractor(userDAO, signupPresenter, docFactory, patFactory);
+
+        SignupInputData inputData = new SignupInputData("taml5", "Testing1", "Testing1", false);
+        signupInteractor.execute(inputData);
+    }
+
+    @Test
+    public void signupDoctorSuccessTest() {
+        SignupUserDataAccessInterface userDAO = new InMemoryUserDataAccessObject();
+        DoctorUserFactory docFactory = new DoctorUserFactory();
+        PatientUserFactory patFactory = new PatientUserFactory();
+        SignupOutputBoundary signupPresenter = new SignupOutputBoundary() {
+            @Override
+            public void prepareSuccessView(SignupOutputData user) {
+                assertTrue(userDAO.existsByName(false, user.getUsername()));
+                assertFalse(user.isUseCaseFailed());
+            }
+
+            @Override
+            public void prepareFailView(String error) {
+                fail("Test expected to pass.");
+            }
+        };
+        SignupInteractor signupInteractor = new SignupInteractor(userDAO, signupPresenter, docFactory, patFactory);
+
+        SignupInputData inputData = new SignupInputData("taml5", "Testing1", "Testing1", true);
+        signupInteractor.execute(inputData);
+    }
+
+    @Test
+    public void signupFailMatchingPasswordsTest() {
+        SignupUserDataAccessInterface userDAO = new InMemoryUserDataAccessObject();
+        DoctorUserFactory docFactory = new DoctorUserFactory();
+        PatientUserFactory patFactory = new PatientUserFactory();
+        SignupOutputBoundary signupPresenter = new SignupOutputBoundary() {
+            @Override
+            public void prepareSuccessView(SignupOutputData user) {
+                fail("Test expected to fail since passwords don't match.");
+            }
+
+            @Override
+            public void prepareFailView(String error) {
+                assertEquals("Passwords don't match.", error);
+                assertFalse(userDAO.existsByName(false, "taml5"));
+            }
+        };
+        SignupInteractor signupInteractor = new SignupInteractor(userDAO, signupPresenter, docFactory, patFactory);
+
+        SignupInputData signupInputData = new SignupInputData("taml5", "Abce45", "Abce5", false);
+        signupInteractor.execute(signupInputData);
+    }
+
+    @Test
+    public void signupFailUserExistingTest() {
+        SignupUserDataAccessInterface userDAO = new InMemoryUserDataAccessObject();
+        DoctorUserFactory docFactory = new DoctorUserFactory();
+        PatientUserFactory patFactory = new PatientUserFactory();
+        SignupOutputBoundary signupPresenter = new SignupOutputBoundary() {
+            @Override
+            public void prepareSuccessView(SignupOutputData user) {
+                fail("Test expected to fail since user already exists.");
+            }
+
+            @Override
+            public void prepareFailView(String error) {
+                assertEquals("User already exists.", error);
+            }
+        };
+        SignupInteractor signupInteractor = new SignupInteractor(userDAO, signupPresenter, docFactory, patFactory);
+        userDAO.save(patFactory.create("taml5", "Abcedf123"));
+
+        SignupInputData signupInputData = new SignupInputData("taml5", "Abce45", "Abce5", false);
+        signupInteractor.execute(signupInputData);
     }
 }


### PR DESCRIPTION
- `SignupView` is now connected to `WelcomeView`: pressing the "Sign Up" button in `WelcomeView` successfully brings the user to `SignupView`
- The `SwapWelcomeView` use case in `SignupView` is now implemented: pressing the "Cancel" button in `SignupView` successfully brings the user to `WelcomeView`
- `SignupView` now correctly shows error messages when passwords don't match or the user already exists in the database (caused by `SignupView` not being a listener to `SignupViewModel`)
- Fixed a bug where error messages would incorrectly display when switching from login/signin views to welcome view and back

